### PR TITLE
Fixed indentation with static functinos

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ dotspacemacs-additional-packages '((gdscript-mode :location local))
 (package! gdscript-mode :recipe (:host github :repo "GDQuest/emacs-gdscript-mode"))
 ```
 
+2. Require the package in your .doom.d/config.el file
+
+```lisp
+(require 'gdscript-mode)
+```
+
 ## Available features ##
 
 - Syntax highlighting for all built-in functions and classes in Godot 3.2

--- a/README.md
+++ b/README.md
@@ -28,11 +28,19 @@ To install it:
 dotspacemacs-additional-packages '((gdscript-mode :location local))
 ```
 
-1. In your user-config function, require the package.
+3. In your user-config function, require the package.
 
 ```lisp
 (defun dotspacemacs/user-config ()
   (require 'gdscript-mode))
+```
+
+### Installing in Doom Emacs ###
+
+1. Add the following line to your .doom.d/packages.el file
+
+```lisp
+(package! gdscript-mode :recipe (:host github :repo "GDQuest/emacs-gdscript-mode"))
 ```
 
 ## Available features ##

--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -410,7 +410,7 @@ It makes underscores and dots word constituent chars.")
   "Gdscript mode specialized rx macro.
 This variant of `rx' supports common Gdscript named REGEXPS."
   `(rx-let ((block-start       (seq symbol-start
-                                    (or "func" "class" "if" "elif" "else"
+                                    (or "func" "static" "class" "if" "elif" "else"
                                         "for" "while" "match")
                                     symbol-end))
             (dedenter          (seq symbol-start

--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -2,11 +2,12 @@
 ;; URL: https://github.com/GDQuest/emacs-gdscript-mode
 ;; Version: 202001141-git
 (add-to-list 'auto-mode-alist '("\\.gd\\'" . gdscript-mode))
+(add-to-list 'auto-mode-alist '("\\.tscn\\'" . conf-toml-mode))
 
 (defgroup gdscript nil
   "GDScript language support for Emacs."
   :group 'languages
-  :version "26.1"
+  :version "27"
   :link '(emacs-commentary-link "gdscript"))
 
 (defvar gdscript-mode-map (let ((map (make-sparse-keymap)))
@@ -22,7 +23,6 @@
                             map)
   "Keymap for `gdscript-mode'.")
 
-
 ;; Lists of keywords in the language
 (defvar gdscript-keywords '("if" "elif" "else" "for" "do" "while" "match"
                             "switch" "case" "break" "continue" "pass"
@@ -249,9 +249,7 @@
 (defun regex-maker (words)
   (regexp-opt words 'symbols))
 
-
 ;;; Font-lock and syntax
-
 (eval-and-compile (defun gdscript-syntax--context-compiler-macro (form type &optional syntax-ppss)
                     (pcase type
                       (''comment


### PR DESCRIPTION
static functions did not indent properly, now they do.