### PR TITLE
Open and run the project in the Godot editor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This document lists new features, improvements, changes, and bug fixes in each release of the package.
 
+## GDScript mode 1.0.3 ##
+
+### New features ###
+
+- Added functions to run (start) Godot Engine from Emacs.
+
 ## GDScript mode 1.0.2 ##
 
 ### Changes ###

--- a/README.md
+++ b/README.md
@@ -133,9 +133,15 @@ pip3 install gdtoolkit
 
 ## Customization
 
-Set the following variables to customize gdscript-mode:
+To customize gdscript-mode, either use `M-x customize` or set the variables
+defined in `gdscript-customization`. For example:
 
 ```lisp
-(setq gdscript-tabs-mode t) ;; If true, use tabs for indents. Default: t
-(setq gdscript-tab-width 4) ;; Controls the width of tab-based indents
+(setq gdscript-use-tab-indents t) ;; If true, use tabs for indents. Default: t
+(setq gdscript-indent-offset 4) ;; Controls the width of tab-based indents
+
+;; Path to Godot binary. Default: "godot" (in PATH)
+(setq gdscript-godot-executable "path/to/godot")
+;; Name of the buffer to display the output of Godot process. Default: *Godot*
+(setq gdscript-godot-shell-buffer-name "*Output-Buffer*")
 ```

--- a/gdscript-customization.el
+++ b/gdscript-customization.el
@@ -103,6 +103,19 @@ fill parens."
   :type 'integer
   :safe 'natnump)
 
+(defcustom gdscript-godot-executable "godot"
+  "The path to the Godot executable.
+By default, it assumes that the executable is in the system's
+PATH."
+  :type 'string
+  :group 'gdscript)
+
+(defcustom gdscript-godot-shell-buffer-name "*Godot*"
+  "Default buffer name for Godot running process."
+  :type 'string
+  :group 'gdscript
+  :safe 'stringp)
+
 (provide 'gdscript-customization)
 
 ;;; gdscript-customization.el ends here

--- a/gdscript-godot.el
+++ b/gdscript-godot.el
@@ -1,0 +1,111 @@
+;;; gdscript-godot.el --- Functions to run Godot Engine in gdscript-mode -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 GDQuest
+
+;; Author: Nathan Lovato <nathan@gdquest.com>, Fabián E. Gallina <fgallina@gnu.org>
+;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "26.3"))
+;; Maintainer: nathan@gdquest.com
+;; Created: Jan 2020
+;; Keywords: languages
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+;;; Commentary:
+
+;; Functions to run the Godot Engine within gdscript-mode.
+
+;;; Code:
+
+(require 'gdscript-utils)
+
+;;;###autoload
+(defun gdscript-godot-run-command (cmd &optional show)
+  "Run a Godot process.
+
+If SHOW, the output of the process will be provided in a buffer
+named after `gdscript-godot-shell-buffer-name'."
+  (interactive)
+  (start-process-shell-command "Godot Process"
+                               (if show
+                                   gdscript-godot-shell-buffer-name
+                                 nil)
+                               cmd))
+
+(defun gdscript-godot-run-godot-editor ()
+  "Run Godot Engine Editor."
+  (interactive)
+  (gdscript-godot-run-command
+   (concat (gdscript-godot--build-shell-command) " -e")))
+
+(defun gdscript-godot-run-project ()
+  "Run the current project in Godot Engine."
+  (interactive)
+  (let* ((project-path (gdscript-util--find-project-configuration-path)))
+    (gdscript-godot-run-command
+     (gdscript-godot--build-shell-command))))
+
+(defun gdscript-godot-run-project-debug-mode ()
+  "Run the current project in Godot Engine."
+  (interactive)
+  (let* ((project-path (gdscript-util--find-project-configuration-path)))
+    (gdscript-godot-run-command
+     (concat (gdscript-godot--build-shell-command) " -d")
+     t)))
+
+(defun gdscript-godot-run-current-scene ()
+  "Run the current script file in Godot Engine."
+  (interactive)
+  (gdscript-godot-run-command
+   (concat (gdscript-godot--build-shell-command) " "
+           (gdscript-godot--get-file-relative-path-to-project buffer-file-name) ".tscn")))
+
+(defun gdscript-godot-run-current-scene-debug-mode ()
+  "Run the current script file in Godot Engine."
+  (interactive)
+  (gdscript-godot-run-command
+   (concat (gdscript-godot--build-shell-command) " -d "
+           (gdscript-godot--get-file-relative-path-to-project buffer-file-name) ".tscn")
+   t))
+
+(defun gdscript-godot-edit-current-scene ()
+  "Run the current script file in Godot Engine."
+  (interactive)
+  (gdscript-godot-run-command
+   (concat (gdscript-godot--build-shell-command) " -e "
+           (gdscript-godot--get-file-relative-path-to-project buffer-file-name) ".tscn")))
+
+(defun gdscript-godot-run-current-script ()
+  "Run the current script file in Godot Engine.
+
+For this to work, the script must inherit either from
+\"SceneTree\" or \"MainLoop\"."
+  (interactive)
+  (gdscript-godot-run-command
+   (concat (gdscript-godot--build-shell-command) " -s " (file-relative-name buffer-file-name))
+   t))
+
+(defun gdscript-godot--build-shell-command (&optional path)
+  "Build base shell command to run Godot Engine with the project's base PATH.
+
+If PATH is not provided, try to find it using the current file's
+directory as starting point."
+  (let* ((project-path (or path (gdscript-util--find-project-configuration-path))))
+    (concat gdscript-godot-executable " --path " project-path)))
+
+(provide 'gdscript-godot)
+
+;;; gdscript-godot.el ends here

--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -38,6 +38,7 @@
 (require 'gdscript-completion)
 (require 'gdscript-format)
 (require 'gdscript-rx)
+(require 'gdscript-godot)
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.gd\\'" . gdscript-mode))
@@ -57,6 +58,14 @@
                             (define-key map "\177" 'gdscript-indent-dedent-line-backspace)
                             (define-key map (kbd "<backtab>") 'gdscript-indent-dedent-line)
                             (define-key map (kbd "\t") 'company-complete)
+                            ;; Run in Godot.
+                            (define-key map "\C-c\C-r\C-e" #'gdscript-godot-run-godot-editor)
+                            (define-key map "\C-c\C-r\C-r" #'gdscript-godot-run-project)
+                            (define-key map "\C-c\C-r\C-d" #'gdscript-godot-run-project-debug-mode)
+                            (define-key map "\C-c\C-r\C-l" #'gdscript-godot-edit-current-scene)
+                            (define-key map "\C-c\C-r\C-s" #'gdscript-godot-run-current-scene)
+                            (define-key map "\C-c\C-r\C-t" #'gdscript-godot-run-current-scene-debug-mode)
+                            (define-key map "\C-c\C-r\C-c" #'gdscript-godot-run-current-script)
                             map)
   "Keymap for `gdscript-mode'.")
 


### PR DESCRIPTION
Hello, @NathanLovato,
How are you?

A long time ago, I was waiting for LSP support in Godot to update my Emacs major
mode. LSP support has recently been added to 3.2; I was about to work on it,
when I found your new mode mentioned in
<https://github.com/emacs-lsp/lsp-mode/pull/1377>.

You have submitted your package to Melpa as well. Thanks for your work and well
done!

From what I can tell, your mode is almost at parity with mine. Some of your open
issues are features that I had implemented long ago; I would be glad to share
them with you.


**Please check if the PR fulfills these requirements:**

- [ ] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes.
    - [ ] You updated the docs or changelog.

I have not read the code style guidelines yet.
Also, I had implemented the changes before seeing this pull request template, so I have not updated the changelog.

Related issue (if applicable): Closes #11 and #13 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

This pull request allows Emacs to run scenes and scripts in Godot. It should
close Issues #11 and #13.

**Does this PR introduce a breaking change?**

It does not change the original API; therefore, I suppose not.

## New feature or change ##


**What is the current behavior?** 

The programmer manually starts an instance of Godot engine to run her/his 
code.

**What is the new behavior?**

The main features are the interactive functions added to the `gdscript-mode-map`
to start an instance of Godot engine and do something with it (open the editor,
run a scene, or run a script).


**Other information**

As I am Evil user, the keybinds probably do not make any sense. Feel free to
change them (or tell me how you would prefer them). For instance, a group for
the commands could be an improvement.

Currently, you have to close the instance after it is running. It could be
changed to close this instance automatically before running a new one.

However, there may be a better alternative as I have not check LSP in detail
yet. If it allows to send commands to control the Godot editor, a better
approach could be keeping an instance running at all times, then just tell Godot
to re-run the code whenever it is desired.

Regarding Issue #6, I have a repository of snippets available at
<https://github.com/francogarcia/yasnippet-godot-gdscript>. If you are
interested, I can update them.

Best regards,
Franco
