### PR TITLE
Fix the names of variables that control indentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,6 @@ pip3 install gdtoolkit
 Set the following variables to customize gdscript-mode:
 
 ```lisp
-(setq gdscript-tabs-mode t) ;; If true, use tabs for indents. Default: t
-(setq gdscript-tab-width 4) ;; Controls the width of tab-based indents
+(setq gdscript-use-tab-indents t) ;; If true, use tabs for indents. Default: t
+(setq gdscript-indent-offset 4) ;; Controls the width of tab-based indents
 ```


### PR DESCRIPTION
Hello, @NathanLovato ,
How are you?

This is a minor fix to the documentation, as I believe that
the variable names are incorrect.

These are the correct names of the variables defined at
`gdscript-customization.el`. Otherwise, the user will not
be able to indent her/his code with spaces.

Best regards,
Franco
