### PR TITLE
Address omissions from fa26dd5 refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This document lists new features, improvements, changes, and bug fixes in each release of the package.
 
+## GDScript mode 1.1.1
+
+### Bug fixes
+
+- Fixed loading the `gdscript-godot` module at initialization.
+- Fixed function calls in the mode map.
+
 ## GDScript mode 1.1.0
 
 Emacs GDScript mode is now available on the [MELPA](https://melpa.org/) package archive!

--- a/gdscript-godot.el
+++ b/gdscript-godot.el
@@ -38,19 +38,10 @@
 ;;;###autoload
 (defun gdscript-run-command (cmd &optional show)
   "Run a Godot process.
-Input and output via buffer named after `*godot*'. If there is a process
-already running in that buffer, just switch to it.
 
-With argument, allows you to define CMD so you can edit the
-command used to call the interpreter.
-When numeric prefix arg is other than 0 or 4 do not SHOW."
-  (interactive
-   (if current-prefix-arg
-       (list
-        (read-string "Run Godot: " (gdscript-godot--build-shell-command))
-        (y-or-n-p "Make dedicated process? ")
-        (= (prefix-numeric-value current-prefix-arg) 4))
-     (list (gdscript-godot--build-shell-command) nil t)))
+CMD is the command to be invoked by the shell.  If SHOW, the
+output of the process will be provided in a buffer named
+`*godot*'."
   (start-process-shell-command "Godot Process" (if show
                                                    "*godot*" nil) cmd))
 
@@ -71,16 +62,14 @@ file's directory as starting point."
 (defun gdscript-godot-run-project ()
   "Run the current project in Godot Engine."
   (interactive)
-  (let* ()
-    (gdscript-run-command
-     (gdscript-godot--build-shell-command))))
+  (gdscript-run-command
+   (gdscript-godot--build-shell-command)))
 
 (defun gdscript-godot-run-project-debug ()
   "Run the current project in Godot Engine."
   (interactive)
-  (let* ()
-    (gdscript-run-command
-     (concat (gdscript-godot--build-shell-command) " -d"))))
+  (gdscript-run-command
+   (concat (gdscript-godot--build-shell-command) " -d") t))
 
 (defun gdscript-godot-run-current-scene ()
   "Run the current script file in Godot Engine."
@@ -94,7 +83,8 @@ file's directory as starting point."
   (interactive)
   (gdscript-run-command
    (concat (gdscript-godot--build-shell-command) " -d "
-           (gdscript-util--get-godot-project-file-path-relative buffer-file-name) ".tscn")))
+           (gdscript-util--get-godot-project-file-path-relative buffer-file-name) ".tscn")
+   t))
 
 (defun gdscript-godot-edit-current-scene ()
   "Run the current script file in Godot Engine."
@@ -110,7 +100,8 @@ For this to work, the script must inherit either from
 \"SceneTree\" or \"MainLoop\"."
   (interactive)
   (gdscript-run-command
-   (concat (gdscript-godot--build-shell-command) " -s " (file-relative-name buffer-file-name))))
+   (concat (gdscript-godot--build-shell-command) " -s " (file-relative-name buffer-file-name))
+   t))
 
 (provide 'gdscript-godot)
 ;;; gdscript-godot.el ends here

--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -38,6 +38,7 @@
 (require 'gdscript-completion)
 (require 'gdscript-format)
 (require 'gdscript-rx)
+(require 'gdscript-godot)
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.gd\\'" . gdscript-mode))
@@ -58,13 +59,13 @@
                             (define-key map (kbd "<backtab>") 'gdscript-indent-dedent-line)
                             (define-key map (kbd "\t") 'company-complete)
                             ;; Run in Godot.
-                            (define-key map "\C-c\C-g" 'gdscript--run-godot-editor)
-                            (define-key map "\C-c\C-p" 'gdscript--run-project-in-godot)
-                            (define-key map "\C-c\C-s" 'gdscript--run-current-scene-in-godot)
-                            (define-key map "\C-c\C-e" 'gdscript-godot-edit-current-scene)
-                            (define-key map "\C-c\C-r" 'gdscript--run-current-script-in-godot)
-                            (define-key map "\C-c\C-dp" 'gdscript--run-project-in-godot-debug-mode)
-                            (define-key map "\C-c\C-ds" 'gdscript--run-current-scene-in-godot-debug-mode)
+                            (define-key map "\C-c\C-r\C-p" 'gdscript-godot-open-project-in-editor)
+                            (define-key map "\C-c\C-r\C-r" 'gdscript-godot-run-project)
+                            (define-key map "\C-c\C-r\C-d" 'gdscript-godot-run-project-debug)
+                            (define-key map "\C-c\C-r\C-s" 'gdscript-godot-run-current-scene)
+                            (define-key map "\C-c\C-r\C-q" 'gdscript-godot-run-current-scene-debug)
+                            (define-key map "\C-c\C-r\C-e" 'gdscript-godot-edit-current-scene)
+                            (define-key map "\C-c\C-r\C-x" 'gdscript-godot-run-current-script)
                             map)
   "Keymap for `gdscript-mode'.")
 

--- a/gdscript-utils.el
+++ b/gdscript-utils.el
@@ -115,8 +115,7 @@ WARNING: the Godot project must exist for this function to work."
 
 (defun gdscript-util--get-godot-project-file-path-relative (file-path)
   "Return the relative path of `FILE-PATH' to Godot's configuration file."
-  (concat (gdscript-godot--build-shell-command) " -d "
-          (file-name-sans-extension
+  (concat (file-name-sans-extension
            (file-relative-name file-path
                                (gdscript-util--find-project-configuration-file)))))
 


### PR DESCRIPTION
Hello again, Nathan,
How are you?

Sorry, I could not review the merge earlier.
I believe that the following changes are necessary to fix it.

Regarding the function `gdscript-run-command`, I removed the part mentioning the dedicated process, as I had not ported the comint features from my mode to here.

The empty `let` statements can be removed. The note about unused variable was due to a refactor I have done when porting my implementation to this repository.

The `t` parameter in debug functions shows Godot's output to the Emacs buffer.

The `gdscript-util--get-godot-project-file-path-relative` was modified when creating the new module, to make it more portable and usable elsewhere.

Finally, we load the module when the package is initialized -- otherwise, the functions will not be available for use.
The key-map was also updated, as it was using the old function names. I introduced a category to organize them.

Regarding the snippets package, sure, let us do it. Yasnippet is very versatile, so there are always room for creativity.

I believe I will link my mode's repository (<https://github.com/francogarcia/godot-gdscript.el/>) to yours.

Thank you for your work!
I have backed your courses, which are fantastic as well.

Best regards,
Franco
