### PR TITLE
Added a command to insert a file path at point using Projectile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This document lists new features, improvements, changes, and bug fixes in each release of the package.
 
+## GDScript mode 1.?.?
+
+### Features
+
+- Added a command to insert a path to a project file.
+
 ## GDScript mode 1.1.1
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,11 @@
 
 This document lists new features, improvements, changes, and bug fixes in each release of the package.
 
-## GDScript mode 1.?.?
+## GDScript mode 1.1.1
 
 ### Features
 
 - Added a command to insert a path to a project file.
-
-## GDScript mode 1.1.1
 
 ### Bug fixes
 

--- a/gdscript-completion.el
+++ b/gdscript-completion.el
@@ -5,7 +5,7 @@
 ;; Author: Nathan Lovato <nathan@gdquest.com>, Fabián E. Gallina <fgallina@gnu.org>
 ;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
 ;; Version: 0.1.0
-;; Package-Requires: ((emacs "26.3") (projectile "2.1.0"))
+;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com
 ;; Created: Feb 2020
 ;; Keywords: languages
@@ -34,7 +34,6 @@
 
 (require 'gdscript-syntax)
 (require 'gdscript-utils)
-(require 'projectile)
 
 (defvar-local gdscript-completion--all-keywords
   (eval-when-compile (append gdscript-keywords gdscript-built-in-classes
@@ -53,19 +52,34 @@
 (defun gdscript-completion-insert-file-path-at-point (&optional arg)
   "Insert a file path at point using Godot's relative path (\"res:\").
 
-With a prefix ARG invalidates the cache first. If invoked outside
-of a project, displays a list of known projects to jump."
+If Projectile is available, list only the files in the current
+project.  Otherwise, fallback to the built-in function
+`read-file-name'.
+
+If using Projectile, with a prefix ARG invalidates the cache
+first."
   (interactive "P")
-  (projectile-maybe-invalidate-cache arg)
-  (let* ((project-root (projectile-ensure-project (projectile-project-root)))
-         (file (projectile-completing-read
-                "Find file: "
-                (projectile-project-files project-root))))
-    (when file
-      (insert
-       (concat "\"res://"
-               (gdscript-util--get-godot-project-file-path-relative file)
-               "." (file-name-extension file) "\"")))))
+  (let ((has-projectile (featurep 'projectile)))
+    (when has-projectile
+      (projectile-maybe-invalidate-cache arg))
+    (let* ((project-root
+            (if has-projectile
+                (projectile-ensure-project (projectile-project-root))
+              (gdscript-util--find-project-configuration-file)))
+           (file
+            (if has-projectile
+                (projectile-completing-read
+                 "Find file: "
+                 (projectile-project-files project-root))
+              (read-file-name
+               "Find file: "
+               project-root))))
+      (when file
+        (insert
+         (concat "\"res://"
+                 (gdscript-util--get-godot-project-file-path-relative file)
+                 "." (file-name-extension file) "\""))))))
+
 
 (provide 'gdscript-completion)
 

--- a/gdscript-completion.el
+++ b/gdscript-completion.el
@@ -5,7 +5,7 @@
 ;; Author: Nathan Lovato <nathan@gdquest.com>, Fabián E. Gallina <fgallina@gnu.org>
 ;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
 ;; Version: 0.1.0
-;; Package-Requires: ((emacs "26.3"))
+;; Package-Requires: ((emacs "26.3") (projectile "2.1.0"))
 ;; Maintainer: nathan@gdquest.com
 ;; Created: Feb 2020
 ;; Keywords: languages
@@ -33,6 +33,8 @@
 ;;; Code:
 
 (require 'gdscript-syntax)
+(require 'gdscript-utils)
+(require 'projectile)
 
 (defvar-local gdscript-completion--all-keywords
   (eval-when-compile (append gdscript-keywords gdscript-built-in-classes
@@ -47,6 +49,23 @@
          (end (cdr bounds)))
     (list start end gdscript-completion--all-keywords
           . nil)))
+
+(defun gdscript-completion-insert-file-path-at-point (&optional arg)
+  "Insert a file path at point using Godot's relative path (\"res:\").
+
+With a prefix ARG invalidates the cache first. If invoked outside
+of a project, displays a list of known projects to jump."
+  (interactive "P")
+  (projectile-maybe-invalidate-cache arg)
+  (let* ((project-root (projectile-ensure-project (projectile-project-root)))
+         (file (projectile-completing-read
+                "Find file: "
+                (projectile-project-files project-root))))
+    (when file
+      (insert
+       (concat "\"res://"
+               (gdscript-util--get-godot-project-file-path-relative file)
+               "." (file-name-extension file) "\"")))))
 
 (provide 'gdscript-completion)
 

--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -58,6 +58,8 @@
                             (define-key map "\177" 'gdscript-indent-dedent-line-backspace)
                             (define-key map (kbd "<backtab>") 'gdscript-indent-dedent-line)
                             (define-key map (kbd "\t") 'company-complete)
+                            ;; Insertion.
+                            (define-key map "\C-c\C-f" 'gdscript-completion-insert-file-path-at-point)
                             ;; Run in Godot.
                             (define-key map "\C-c\C-r\C-p" 'gdscript-godot-open-project-in-editor)
                             (define-key map "\C-c\C-r\C-r" 'gdscript-godot-run-project)


### PR DESCRIPTION
Hello, @NathanLovato ,
How are you?

**Please check if the PR fulfills these requirements:**

- [X] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes.
    - [X] You updated the docs or changelog.


Related issue (if applicable): Closes #36.

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

A command to insert the path of a project file at point using Projectile.

**Does this PR introduce a breaking change?**

It retains the previous API. However, Projectile becomes a requirement for the package.

## New feature or change ##


**What is the current behavior?** 

The user has (a) either to type the path manually or (b) insert the path, then edit the prefix.

**What is the new behavior?**

After `gdscript-completion-insert-file-path-at-point`, a quoted path to the chosen file is added automatically at the point.

**Other information**

If `gdscript-completion` is not the appropriate place for the function, feel free to change it. Furthermore, I do not know the minimum version of Projectile you are aiming to require. I have just added the current stable version.

I should refactor `gdscript-util--get-godot-project-file-path-relative` to strip the file name at some point.

Best regards,
Franco
