### PR TITLE
Format buffer and region.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This document lists new features, improvements, changes, and bug fixes in each release of the package.
 
+## GDScript mode 1.?.?
+
+### Features
+
+- Added a command to format a selected region with `gdformat`.
+
 ## GDScript mode 1.2.0
 
 ### Features

--- a/gdscript-customization.el
+++ b/gdscript-customization.el
@@ -110,5 +110,12 @@ PATH."
   :type 'string
   :group 'gdscript)
 
+(defcustom gdscript-gdformat-executable "gdformat"
+  "The path to the gdformat executable.
+By default, it assumes that the executable is in the system's
+PATH."
+  :type 'string
+  :group 'gdscript)
+
 (provide 'gdscript-customization)
 ;;; gdscript-customization.el ends here

--- a/gdscript-format.el
+++ b/gdscript-format.el
@@ -31,65 +31,29 @@
 
 ;;; Code:
 
-(defun gdscript-format--run-gdformat (buffer-input buffer-output buffer-error)
-  "Call gdformat process.
-Argument BUFFER-INPUT reference to the input buffer to format.
-Argument BUFFER-OUTPUT the buffer to write the output of the gdformat call.
-Argument BUFFER-ERROR the buffer to write errors to."
-  (with-current-buffer buffer-input
-    (let ((process (make-process :name "gdformat"
-                                 :command (list "gdformat" "-"):buffer
-                                 buffer-output
-                                 :stderr buffer-error
-                                 :noquery t
-                                 :sentinel (lambda (_process _event)))))
-      (set-process-query-on-exit-flag (get-buffer-process buffer-error)
-                                      nil)
-      (set-process-sentinel (get-buffer-process buffer-error)
-                            (lambda (_process _event)))
-      (save-restriction (widen)
-                        (process-send-region process
-                                             (point-min)
-                                             (point-max)))
-      (process-send-eof process)
-      (accept-process-output process nil nil t)
-      (while (process-live-p process)
-        (accept-process-output process nil nil t))
-      (process-exit-status process))))
+(defun gdscript-format--format-region (start end)
+  "Format the region between START and END using `gdformat'."
+  (save-excursion
+    (shell-command-on-region
+     start end
+     (concat
+      "echo "
+      (shell-quote-argument (buffer-substring start end))
+      "|"
+      gdscript-gdformat-executable " -")
+     (buffer-name) t)))
 
-(defun gdscript-format-buffer ()
-  "Formats current buffer using 'gdformat'."
+(defun gdscript-format-region()
+  "Format the selected region using `gdformat'"
   (interactive)
-  (let* ((buffer-start (current-buffer))
-         (point-start (point))
-         (window-pos-start (window-start))
-         (buffer-temp (get-buffer-create "*gdformat*"))
-         (buffer-error (get-buffer-create "*gdformat-error*")))
-    (dolist (buf (list buffer-temp buffer-error))
-      (with-current-buffer buf
-        (erase-buffer)))
-    (condition-case err
-        (if (/= 0 (gdscript-format--run-gdformat buffer-start buffer-temp
-                                                 buffer-error))
-            (error "GDSCript formatter: failed, see buffer %s for details"
-                   (buffer-name buffer-error))
-          (if (/= 0 (compare-buffer-substrings buffer-temp nil
-                                               nil buffer-start nil nil))
-              (progn
-                (with-current-buffer buffer-temp
-                  (copy-to-buffer buffer-start
-                                  (point-min)
-                                  (point-max)))
-                (goto-char point-start)
-                (set-window-start (selected-window)
-                                  window-pos-start)
-                (message "gdscript formatter: success"))
-            (message "gdscript formatter: nothing to do"))
-          (mapc 'kill-buffer
-                (list buffer-temp buffer-error)))
-      (error (message "%s"
-                      (error-message-string err))
-             (pop-to-buffer buffer-error)))))
+  (gdscript-format--format-region
+   (region-beginning) (region-end)))
+
+(defun gdscript-format-buffer()
+  "Format the entire current buffer using `gdformat'"
+  (interactive)
+  (gdscript-format--format-region
+   (point-min) (point-max)))
 
 (provide 'gdscript-format)
 

--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -60,6 +60,9 @@
                             (define-key map (kbd "\t") 'company-complete)
                             ;; Insertion.
                             (define-key map "\C-c\C-f" 'gdscript-completion-insert-file-path-at-point)
+                            ;; Formatting.
+                            (define-key map "\C-c\C-t\C-r" 'gdscript-format-region)
+                            (define-key map "\C-c\C-t\C-t" 'gdscript-format-buffer)
                             ;; Run in Godot.
                             (define-key map "\C-c\C-r\C-p" 'gdscript-godot-open-project-in-editor)
                             (define-key map "\C-c\C-r\C-r" 'gdscript-godot-run-project)


### PR DESCRIPTION
Hello, @NathanLovato ,
How are you?

**Please check if the PR fulfills these requirements:**

- [X] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes.
    - [X] You updated the docs or changelog.


Related issue (if applicable): Closes #38.

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

Besides the introduction of the ability to format a region, this commit has:

- Simplified the implementation;
- Introduced keybindings;
- Provided the ability to customize the path to `gdformat`.

**Does this PR introduce a breaking change?**

No. It retains the previous API.

## New feature or change ##


**What is the current behavior?** 

Only the entire buffer can be formatted.

**What is the new behavior?**

The entire buffer as well as regions of it can be formatted.

**Other information**

I believe that the new implementation is easier to read and maintain.

Best regards,
Franco

Closes #45 