### PR TITLE
Add syntax highlighting for function calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _Currently in development._
 
 - Added a command to insert a path to a project file, either using `project-find-file` if `projectile` is available, otherwise with `find-file`.
 - Added a command to format a selected region with `gdformat`.
+- Added syntax highlighting for function calls.
 
 ### Bug fixes
 

--- a/gdscript-syntax.el
+++ b/gdscript-syntax.el
@@ -75,7 +75,12 @@
                                    (or "var" "const")
                                    (1+ space)
                                    (group (1+ (or word ?_))))
-                              (1 font-lock-variable-name-face))))
+                              (1 font-lock-variable-name-face))
+                             ;; Function call
+                             (,(rx (group (1+ (or word ?_)))
+                                   (0+ space)
+                                   "(")
+                              (1 font-lock-function-name-face))))
 
 (defvar gdscript-syntax-table (make-syntax-table))
 


### PR DESCRIPTION
Hello, @NathanLovato ,
How are you?

**Please check if the PR fulfills these requirements:**

- [X] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes.
    - [X] You updated the docs or changelog.


Related issue (if applicable): Closes #30.

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

The commit add syntax highlighting for function calls.

**Does this PR introduce a breaking change?**

No.

## New feature or change ##


**What is the current behavior?** 

Function calls are shown in the editor using the regular face.

**What is the new behavior?**

Function calls are shown in the editor using the `font-lock-function-name-face`.

**Other information**

The implementation uses `"("` instead `(syntax open-parenthesis)` as
`open-parenthesis` is defined from `(open-paren (or "{" "[" "("))`. As a result,
the regular expression would also highlight array and dictionary variables.

The regular expression does highlight signal definitions with parameters,
though, as they follow the same pattern of function calls. This could be avoided
by ignoring expressions started with "signal" (or by adding a custom rule to
highlight signal definitions).

I think this closes the last issue that required implementation, as it seems that
#25 was implemented in #27, although it is waiting to be merged in another
repository.

I believe that #13 was addressed by #40. If there is still need to change
something (for instance, introduce a variable to add parameters to the 
executable), just let me know.

Best regards,
Franco