### PR TITLE
Add missing keywords (puppet, remotesync)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _Currently in development._
 
 ### Features
 
+- Added missing puppet and remotesync keywords
 - Added a command to insert a path to a project file, either using `project-find-file` if `projectile` is available, otherwise with `find-file`.
 - Added a command to format a selected region with `gdformat`.
 - Added syntax highlighting for function calls.

--- a/gdscript-keywords.el
+++ b/gdscript-keywords.el
@@ -33,7 +33,7 @@
 
 (defconst gdscript-keywords '("and" "as" "assert" "break" "breakpoint" "case" "class" "class_name"
 "const" "continue" "do" "elif" "else" "enum" "export" "extends" "false" "for" "func" "if" "in" "is"
-"master" "match" "not" "onready" "or" "pass" "preload" "remote" "return" "self" "setget" "signal"
+"master" "match" "not" "onready" "or" "pass" "preload" "puppet" "remote" "remotesync" "return" "self" "setget" "signal"
 "slave" "static" "switch" "sync" "tool" "true" "var" "while" "yield"))
 (defconst gdscript-built-in-constants '("INF" "NAN" "PI" "TAU"))
 ;; Only contains types that are not classes and that the Godot editor highlights


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [x] You updated the docs or changelog.

**What kind of change does this PR introduce?**
Adds the [missing puppet and remotesync keywords](https://docs.godotengine.org/en/latest/tutorials/networking/high_level_multiplayer.html#back-to-lobby)

**Does this PR introduce a breaking change?**
No, I left the old version "slave" there for now as a nod to older GD versions

## New feature or change ##


**What is the current behavior?** 
`remotesync` and `puppet` keywords are not highlighted

**What is the new behavior?**
`remotesync` and `puppet` keywords are highlighted


