### PR TITLE
format-buffer: preserve point instead of jumping to the top of the file

### DIFF
--- a/gdscript-format.el
+++ b/gdscript-format.el
@@ -52,8 +52,12 @@
 (defun gdscript-format-buffer()
   "Format the entire current buffer using `gdformat'"
   (interactive)
-  (gdscript-format--format-region
-   (point-min) (point-max)))
+  (let ((original-point (point))
+        (original-window-pos (window-start)))
+    (gdscript-format--format-region
+     (point-min) (point-max))
+    (goto-char original-point)
+    (set-window-start (selected-window) original-window-pos)))
 
 (provide 'gdscript-format)
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [X] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

Changes `gdscript-format-buffer` such that you aren't jumped to the start of a file after a format happens.

**Does this PR introduce a breaking change?**

No.

## New feature or change ##


**What is the current behavior?** 

Now, when you use `gdscript-format-buffer` as an after-save hook (or otherwise), you are moved from your current editing position to the top of the file.

**What is the new behavior?**

With this change, your editing position in the buffer is preserved when a reformat happens.

**Other information**

As noted in the commit message, this was inspired by [how blacken.el does this](https://github.com/pythonic-emacs/blacken/blob/3bdb26788e4b5a870b3eebcf610473af5806bb2f/blacken.el#L140).