### PR TITLE
Only replace the formatted buffer if the gdformat exits with a 0

### DIFF
--- a/gdscript-format.el
+++ b/gdscript-format.el
@@ -33,15 +33,15 @@
 
 (defun gdscript-format--format-region (start end)
   "Format the region between START and END using `gdformat'."
-  (save-excursion
-    (shell-command-on-region
-     start end
-     (concat
-      "echo "
-      (shell-quote-argument (buffer-substring start end))
-      "|"
-      gdscript-gdformat-executable " -")
-     (buffer-name) t)))
+  (let
+      ((cmd (concat "echo " (shell-quote-argument (buffer-substring start end)) "|" gdscript-gdformat-executable " -"))
+       (error-buffer "*gdformat-errors*"))
+    (if (eq (with-temp-buffer (call-process-shell-command cmd)) 0)
+        (save-excursion
+          (shell-command-on-region start end cmd (buffer-name) t error-buffer t))
+      (progn
+        (with-current-buffer error-buffer (erase-buffer))
+        (shell-command-on-region start end cmd nil nil error-buffer t)))))
 
 (defun gdscript-format-region()
   "Format the selected region using `gdformat'"


### PR DESCRIPTION
Closes #51 

**Please check if the PR fulfills these requirements:**

- [X] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

This PR modifies `gdscript-format--format-region` such that it only overwrites your buffer if `gdformat` exits cleanly.

**Does this PR introduce a breaking change?**

No.

## New feature or change ##


**What is the current behavior?** 

Right now, is you use `gdscript-format-region` as a post-save hook on a file with problems - the entire file will be replaced with a python traceback.

**What is the new behavior?**

Now, the command is first ran in a temporary buffer to determine the exit code, if it is 0 then the buffer is replaced.  If not, the error is displayed in a new buffer named `*gdformat-errors*`.

**Other information**

There could very well be a better way to do this, I'm open to suggestions!