### PR TITLE
Fix deindentation for elif and else keywords

### DIFF
--- a/gdscript-rx.el
+++ b/gdscript-rx.el
@@ -1445,10 +1445,9 @@ following constructs:
 (defmacro gdscript-rx (&rest regexps)
   "Gdscript mode specialized rx macro.
 This variant of `rx' supports common Gdscript named REGEXPS."
-  `(gdscript-rx-let ((block-start       (seq (zero-or-more nonl)
-                                             ":"
-                                             (or (seq (zero-or-more " ") eol)
-                                                 (seq (zero-or-more " ") "#" (zero-or-more nonl) eol))))
+  `(gdscript-rx-let ((block-start       (seq symbol-start
+                                             (or "func" "class" "if" "elif" "else" "for" "while" "match")
+                                             symbol-end))
                      (dedenter          (seq symbol-start
                                              (or "elif" "else")
                                              symbol-end))


### PR DESCRIPTION
Fix for #52

This is changing `(gdscript-rx block-start)` so that elif / else
deindentation is working properly.

This is not handling `match` patterns as a blocks, so no deindentation
will work in case of nested match patterns on match branches.

To support that much bigger rewrite would be needed.