### PR TITLE
Godot API browsing using eww

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _Currently in development._
 
 ### Features
 
+- Added convenient way how to browse Godot API with eww
 - Added missing built in functions
 - Added missing puppet and remotesync keywords
 - Added a command to insert a path to a project file, either using `project-find-file` if `projectile` is available, otherwise with `find-file`.

--- a/README.md
+++ b/README.md
@@ -154,13 +154,6 @@ With a point on build-in class you can press `C-c C-r C-o` to open [eww](https:/
 
 Using `C-c C-r C-a` opens main Godot API page in eww.
 
-For convenience add `gdscript-documentation-rename-eww-buffer` to `eww-after-render-hook`. This will rename eww buffer(s) visiting Godot documentation from generic name to one which contains page title.
-
-```
-(use-package gdscript-mode
-    :hook ((eww-after-render . gdscript-documentation-rename-eww-buffer)))
-```
-
 ## Customization
 
 To find all GDScript-mode settings, press `M-x customize` and search for "gdscript".

--- a/README.md
+++ b/README.md
@@ -148,6 +148,19 @@ command in your shell to install it:
 pip3 install gdtoolkit
 ```
 
+### Browsing Godot API with [eww](https://www.gnu.org/software/emacs/manual/html_node/emacs/EWW.html)
+
+With a point on build-in class you can press `C-c C-r C-o` to open [eww](https://www.gnu.org/software/emacs/manual/html_node/emacs/EWW.html) browser with an api documentation for that class.
+
+Using `C-c C-r C-a` opens main Godot API page in eww.
+
+For convenience add `gdscript-documentation-rename-eww-buffer` to `eww-after-render-hook`. This will rename eww buffer(s) visiting Godot documentation from generic name to one which contains page title.
+
+```
+(use-package gdscript-mode
+    :hook ((eww-after-render . gdscript-documentation-rename-eww-buffer)))
+```
+
 ## Customization
 
 To find all GDScript-mode settings, press `M-x customize` and search for "gdscript".

--- a/gdscript-documentation.el
+++ b/gdscript-documentation.el
@@ -1,0 +1,66 @@
+;;; gdscript-documentation.el --- Open documntation in Godot -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2020 GDQuest and contributors
+;;
+;; Author: Josef Vlach <vlach.josef@gmail.com>
+;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; Version: 1.0.0
+;; Package-Requires: ((emacs "26.3"))
+;; Maintainer: nathan@gdquest.com
+;; Created: May 2020
+;; Keywords: languages
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;; Commentary:
+;;
+;;  Browse Godot API documentation in eww browser.
+;;
+;;; Code:
+
+(require 'eww)
+
+;;;###autoload
+(defun gdscript-documentation-api ()
+  "Open main page of Godot API in eww browser."
+  (interactive)
+  (eww-browse-url "https://docs.godotengine.org/en/stable/classes/index.html?#godot-api"))
+
+(defun gdscript-documentation-open ()
+  "Open documention for symbol at point in eww browser.
+If a page is already open, it will switch to its buffer."
+  (interactive)
+  (let* ((symbol (downcase (thing-at-point 'symbol t)))
+         (buffer
+          (seq-find
+           (lambda (current-buffer)
+             (with-current-buffer current-buffer
+               (when (derived-mode-p 'eww-mode)
+                 (string-suffix-p symbol (plist-get eww-data :url) t)
+                 ))) (buffer-list))))
+    (if buffer (pop-to-buffer-same-window buffer)
+      (eww-browse-url (format "https://docs.godotengine.org/en/stable/classes/class_%s.html#%s" symbol symbol) t))))
+
+(defun gdscript-documentation-rename-eww-buffer ()
+  "Rename eww buffer visiting Godot documentation.
+It will rename eww buffer from generic name to name including page title."
+  (when (derived-mode-p 'eww-mode)
+    (let ((title (plist-get eww-data :title)))
+      (when (string-match "Godot Engine" title)
+        (rename-buffer (format "*eww - %s*" title) t)))))
+
+(provide 'gdscript-documentation)
+;;; gdscript-documentation.el ends here

--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -31,6 +31,7 @@
 ;;; Code:
 
 (require 'gdscript-customization)
+(require 'gdscript-documentation)
 (require 'gdscript-syntax)
 (require 'gdscript-indent-and-nav)
 (require 'gdscript-imenu)

--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -71,6 +71,8 @@
                             (define-key map "\C-c\C-r\C-q" 'gdscript-godot-run-current-scene-debug)
                             (define-key map "\C-c\C-r\C-e" 'gdscript-godot-edit-current-scene)
                             (define-key map "\C-c\C-r\C-x" 'gdscript-godot-run-current-script)
+                            (define-key map "\C-c\C-r\C-a" 'gdscript-documentation-api)
+                            (define-key map "\C-c\C-r\C-o" 'gdscript-documentation-open)
                             map)
   "Keymap for `gdscript-mode'.")
 


### PR DESCRIPTION
Convenient way how to browse Godot API without need to leave emacs.

It adds two new commands. 

First one (`gdscript-documentation-api`) is just convenient way how to open main [Godot API](https://docs.godotengine.org/en/stable/classes/index.html?#godot-api) page in eww.

Second one (`gdscript-documentation-open`) is supposed to be used with point on some build-in class (like `KinematicBody2D`). When executed under these condition it will open corresponding [Godot API page](https://docs.godotengine.org/en/stable/classes/class_kinematicbody2d.html#kinematicbody2d).