### PR TITLE
Fix the match block indentation so indent of elif, else still works

### DIFF
--- a/gdscript-rx.el
+++ b/gdscript-rx.el
@@ -1445,9 +1445,10 @@ following constructs:
 (defmacro gdscript-rx (&rest regexps)
   "Gdscript mode specialized rx macro.
 This variant of `rx' supports common Gdscript named REGEXPS."
-  `(gdscript-rx-let ((block-start       (seq symbol-start
-                                             (or "func" "class" "if" "elif" "else" "for" "while" "match")
-                                             symbol-end))
+  `(gdscript-rx-let ((block-start       (seq (zero-or-more nonl)
+                                             ":"
+                                             (or (seq (zero-or-more " ") eol)
+                                                 (seq (zero-or-more " ") "#" (zero-or-more nonl) eol))))
                      (dedenter          (seq symbol-start
                                              (or "elif" "else")
                                              symbol-end))


### PR DESCRIPTION
So #55 broke #32 which in turns broke `elif` and `else` indentation as reported by #52.

This is proper fix for #52 so #32 still works.

