### PR TITLE
Added history of commands and scene/script selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This document lists new features, improvements, changes, and bug fixes in each r
 - Add the ability to open a local copy of the Godot docs with `gdscript-docs-*` commands.
 - Multiple projects support. Every project's `godot` process runs in its own buffer.
 - Godot's standard output and standard error are fed to a `comint` buffer. This allows you to navigate errors and jump to the corresponding source files, using `compilation-*` commands.
+- Hydra supports history of commands for quick re-execution of godot commands. It also provide quick way to run last command again.
+- `gdscript-godot-run-current-scene` commands now offers to run any scene file if current buffer is not a scene file.
+- `gdscript-godot-run-current-script` command now offers to run any script file if current buffer is not a script file.
 
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ The last selected option is saved for the next time you call `gdscript-godot-run
 Running `gdscript-hydra-show` (<kbd>C-c r</kbd>) opens a [hydra](https://github.com/abo-abo/hydra) popup with options to open the editor or run the project, a scene, or a script, including with visual debug options.
 
 ```
-d ( ) Debug   p run current project  t run current script  q quit
-e ( ) Editor  s run current scene    g switch to *godot*
+d ( ) Debug   p run project  t run script  h run from history   q quit
+e ( ) Editor  s run scene    r run last    g switch to *godot*
 
 c [ ] Visible collisions shapes
 n [ ] Visible navigation

--- a/gdscript-comint.el
+++ b/gdscript-comint.el
@@ -65,7 +65,8 @@ When run it will kill existing process if one exists."
         (godot-mode)
         (buffer-disable-undo))
       (erase-buffer)
-      (comint-exec (current-buffer) buffer-name gdscript-godot-executable nil arguments))))
+      (comint-exec (current-buffer) buffer-name gdscript-godot-executable nil arguments)
+      (pop-to-buffer (current-buffer)))))
 
 (define-derived-mode godot-mode comint-mode "godot"
   "Major mode for godot.

--- a/gdscript-history.el
+++ b/gdscript-history.el
@@ -1,0 +1,94 @@
+;;; gdscript-history.el --- History -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2020 GDQuest and contributors
+;;
+;; Author: Josef Vlach <vlach.josef@gmail.com>
+;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; Version: 1.0.0
+;; Package-Requires: ((emacs "26.3"))
+;; Maintainer: nathan@gdquest.com
+;; Created: June 2020
+;; Keywords: languages
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;; Commentary:
+;;
+;;  Keep history of commands for later quick execution.
+;;
+;;; Code:
+
+(require 'gdscript-utils)
+
+(defvar gdscript-history--previous-arguments-plist nil
+  "Holds history of commands per project.")
+
+(defmacro gdscript-history--with-project-history (project-history &rest body)
+  "Execute the forms in BODY with PROJECT-HISTORY being set.
+
+PROJECT-HISTORY will be history of current project."
+  (declare (indent 1) (debug t))
+  `(let* ((property (gdscript-util--find-project-configuration-file))
+          (,project-history (lax-plist-get gdscript-history--previous-arguments-plist property)))
+     ,@body))
+
+(defun gdscript-history--add-to-history (arguments)
+  "Add ARGUMENTS to history for current project."
+  (gdscript-history--with-project-history history
+    (push arguments history)
+    (delete-dups history)
+    (setq gdscript-history--previous-arguments-plist
+          (lax-plist-put gdscript-history--previous-arguments-plist property history))))
+
+(defun gdscript-history--last-command ()
+  "Return last command from history."
+  (gdscript-history--with-project-history history
+    (car history)))
+
+(defun gdscript-history--line-data (command)
+  "Pretty print COMMAND."
+  (let* ((flat (gdscript-util--flatten command))
+         (l (car (last flat))))
+    (cond ((string-suffix-p ".tscn" l)
+           (progn
+             (string-match "\\(.*/\\)?\\(.*\\).tscn$" l)
+             (list (format "Scene %s.tscn: %s " (match-string-no-properties 2 l) l) (butlast command))))
+          ((string-suffix-p ".gd" l)
+           (progn
+             (string-match "\\(.*/\\)?\\(.*\\).gd$" l)
+             (list (format "Script %s.gd: %s " (match-string-no-properties 2 l) l) (butlast command))))
+          (t
+           (list (format "Project %s: " (gdscript-util--get-godot-project-name)) command)))))
+
+(defun gdscript-history--line (command idx)
+  "Render COMMAND as string starting with index IDX."
+  (let* ((index (number-to-string (1+ idx)))
+         (data (gdscript-history--line-data command))
+         (name (car data))
+         (args (cadr data)))
+    (string-trim (concat index ") " name (mapconcat 'identity args " ")))))
+
+(defun gdscript-history--select-from-history ()
+  "Choose command from history."
+  (gdscript-history--with-project-history history
+    (let* ((history-data (seq-map-indexed #'gdscript-history--line history))
+           (selected (gdscript-util--read history-data "Run again"))
+           (index (string-to-number selected)))
+      (nth (1- index) history))))
+
+(provide 'gdscript-history)
+
+;;; gdscript-history.el ends here

--- a/gdscript-project.el
+++ b/gdscript-project.el
@@ -1,0 +1,111 @@
+;;; gdscript-project.el --- Project -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2020 GDQuest and contributors
+;;
+;; Author: Josef Vlach <vlach.josef@gmail.com>
+;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; Version: 1.0.0
+;; Package-Requires: ((emacs "26.3"))
+;; Maintainer: nathan@gdquest.com
+;; Created: June 2020
+;; Keywords: languages
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;; Commentary:
+;;
+;;  Find all scenes/scripts functions.
+;;
+;;; Code:
+
+(require 'gdscript-utils)
+
+(defvar gdscript-project--script-list nil)
+
+(defun gdscript-project--current-buffer-scene ()
+  "Return the name of current scene.
+
+If current buffer is not visiting scene file return nil."
+  (when buffer-file-name
+    (let ((scene-name (concat (gdscript-util--get-godot-project-file-path-relative buffer-file-name) ".tscn")))
+      (when (file-exists-p scene-name) scene-name))))
+
+(defun gdscript-project--select-scene ()
+  "Find all scenes files and let user choose one."
+  (let* ((rl (gdscript-util--find-project-configuration-file))
+         (scene-list (mapcar (lambda (x) (file-relative-name x rl)) (directory-files-recursively rl ".*.tscn" t)))
+         (prompt (format "Buffer %s is not scene file, select scene to run" (buffer-name))))
+    (gdscript-util--read scene-list prompt)))
+
+(defun gdscript-project--current-buffer-script ()
+  "Return the name of current script.
+
+If current buffer is not visiting script file return nil."
+  (when buffer-file-name
+    (save-excursion
+      (goto-char (point-min))
+      (when (re-search-forward "^extends SceneTree\\|^extends MainLoop" nil t)
+        (file-relative-name buffer-file-name (gdscript-util--find-project-configuration-file))))))
+
+(defun gdscript-project--select-script ()
+  "Find all script files and let user choose one."
+  (let ((hydra-open gdscript-hydra--open))
+    (when hydra-open (gdscript-hydra--menu/nil))
+    (unwind-protect
+        (let* ((prompt (format "Buffer %s is not script file, select script to run" (buffer-name)))
+               (script-name (gdscript-util--read gdscript-project--script-list prompt)))
+          (gdscript-godot--run-script script-name))
+      (when hydra-open (gdscript-hydra--menu/body)))))
+
+(defun gdscript-project--ag-cleanup ()
+  "Clean after ag search.
+
+Try to leave Emacs as it was before ag search was launched."
+  (remove-hook 'ag-search-finished-hook #'gdscript-project--ag-find-next-script)
+  (let* ((ag-buffer (current-buffer))
+         (ag-window (get-buffer-window ag-buffer))
+         (prev-buffer (window-prev-buffers ag-window)))
+    (if prev-buffer (kill-buffer ag-buffer)
+      (delete-window ag-window)
+      (kill-buffer ag-buffer))))
+
+(defun gdscript-project--ag-find-next-script ()
+  "Find next script file in ag buffer."
+  (let ((pos (next-single-property-change (point) 'compilation-message))
+        (comp-mes (get-text-property (point) 'compilation-message)))
+    (when comp-mes
+      (let ((file-name (caar (compilation--loc->file-struct (compilation--message->loc comp-mes)))))
+        (push file-name gdscript-project--script-list)))
+    (if pos (progn (goto-char pos)
+                   (gdscript-project--ag-find-next-script))
+      (gdscript-project--ag-cleanup)
+      (with-current-buffer (window-buffer (selected-window))
+        (gdscript-project--select-script)))))
+
+(defun gdscript-project--get-all-scripts ()
+  "Find all script files and let user choose one.
+
+Since detection of script files require inspection of file contents,
+this use ag for performance."
+  (if (not (featurep 'ag))
+      (error (format "Buffer %s is no script file. To see all available scripts in current project install package 'ag'." (buffer-name)))
+    (ag-project-regexp "^extends SceneTree|^extends MainLoop")
+    (setq gdscript-project--script-list nil)
+    (add-hook 'ag-search-finished-hook #'gdscript-project--ag-find-next-script)))
+
+(provide 'gdscript-project)
+
+;;; gdscript-project.el ends here

--- a/gdscript-utils.el
+++ b/gdscript-utils.el
@@ -136,6 +136,18 @@ For example:
    ((listp xs) (append (gdscript-util--flatten (car xs)) (gdscript-util--flatten (cdr xs))))
    (t (list xs))))
 
+(defun gdscript-util--read (items &optional prompt)
+  "Let's choose single item from ITEMS from mini-buffer.
+
+PROMPT is prompt for read command."
+  (let ((p (if prompt prompt "Options")))
+    (cond ((fboundp 'ivy-read)
+           (ivy-read (format "%s: " p) items))
+          ((fboundp 'ido-completing-read)
+           (ido-completing-read (format "%s: " p) items))
+          (t
+           (completing-read (format "%s (hit TAB to auto-complete): " p) items nil t)))))
+
 (provide 'gdscript-utils)
 
 ;;; gdscript-utils.el ends here


### PR DESCRIPTION
There are four distinct features in this PR.

Two are Hydra only: 

1) History - Hydra now keeps track of past commands (what arguments has been passed to godot executable) and it allows to list this history for user to choose any past command again.
2) Run last - quick way to run last command from this history.

Another two new features are:

3) Scene selector
4) Script selector

When launching scene/script and current buffer is not scene/script file user will get chance to choose from all scene/script files in a project.

Scene selector works fine as all functionality is implemented in elisp.

Unfortunately for Script selector to work we need to inspect content of files. As far as I know there is no way how to achieve this in elisp alone. So for this feature to work use `ag` package.