### PR TITLE
Use gdscript-mode-syntax-table instead of gdscript-syntax-table

### DIFF
--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -110,9 +110,9 @@ the last command event was a string delimiter."
   (setq-local tab-width gdscript-tab-width)
   (setq-local indent-tabs-mode gdscript-use-tab-indents)
 
-  (set-syntax-table gdscript-syntax-table)
-  (modify-syntax-entry ?\# "\<" gdscript-syntax-table)
-  (modify-syntax-entry ?\n ">" gdscript-syntax-table)
+  (set-syntax-table gdscript-mode-syntax-table)
+  (modify-syntax-entry ?\# "\<" gdscript-mode-syntax-table)
+  (modify-syntax-entry ?\n ">" gdscript-mode-syntax-table)
 
   (setq-local comment-start "# ")
   (setq-local comment-start-skip "#+\\s-*")

--- a/gdscript-syntax.el
+++ b/gdscript-syntax.el
@@ -56,7 +56,11 @@
                       (_ form))))
 
 ;; Controls font-face mappings or colors to highlight groups of keywords
-(defvar gdscript-font-lock `((,(gdscript-syntax-regex-maker gdscript-keywords)
+(defvar gdscript-font-lock `((,(rx (and "$" (one-or-more (or "/" (one-or-more word)))))
+                              (0 font-lock-constant-face))
+                             (,(rx (and (group "$") "\"" (zero-or-more nonl) "\""))
+                              (1 font-lock-constant-face))
+                             (,(gdscript-syntax-regex-maker gdscript-keywords)
                               1
                               font-lock-keyword-face)
                              (,(gdscript-syntax-regex-maker (append gdscript-built-in-constants
@@ -81,8 +85,6 @@
                                    (0+ space)
                                    "(")
                               (1 font-lock-function-name-face))))
-
-(defvar gdscript-syntax-table (make-syntax-table))
 
 (defun gdscript-syntax-context (type &optional syntax-ppss)
   "Return non-nil if point is on TYPE using SYNTAX-PPSS.


### PR DESCRIPTION
For some reason there were two `syntax-table`s defined one of which was without any customisation (removed by this PR).

Doing so had negative effect on how `$` operator literal were rendered. This is fixed by rendering them with `font-lock-constant-face` face.
