### PR TITLE
Run editor in separated comint-buffer

### DIFF
--- a/gdscript-comint.el
+++ b/gdscript-comint.el
@@ -55,7 +55,7 @@
 
 ARGUMENTS are command line arguments for godot executable.
 When run it will kill existing process if one exists."
-  (let ((buffer-name (gdscript-util--get-godot-buffer-name))
+  (let ((buffer-name (gdscript-util--get-godot-buffer-name (member "-e" arguments)))
         (inhibit-read-only t))
 
     (when (not (executable-find gdscript-godot-executable))

--- a/gdscript-utils.el
+++ b/gdscript-utils.el
@@ -114,9 +114,9 @@ WARNING: the Godot project must exist for this function to work."
         (match-string 1)
       (error "Could not find the name of the project"))))
 
-(defun gdscript-util--get-godot-buffer-name ()
+(defun gdscript-util--get-godot-buffer-name (&optional editor)
   "Return buffer name for godot's stdout/stderr output."
-  (format "*godot - %s*" (gdscript-util--get-godot-project-name)))
+  (format (if editor "*godot - %s - Editor*" "*godot - %s*") (gdscript-util--get-godot-project-name)))
 
 (defun gdscript-util--get-gdformat-buffer-name ()
   "Return buffer name for godot's stdout/stderr output."


### PR DESCRIPTION
When running editor, use dedicated buffer for the process, so it will stay running along side of a project.

In other words launched editor won't be affected by running/killing of a scene project.